### PR TITLE
Add configurable EmailJS IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+config.js
+.DS_Store

--- a/Certifications.html
+++ b/Certifications.html
@@ -145,6 +145,7 @@
             }, 300);
         };
     </script>
+    <script src="config.js"></script>
     <script src="scripts.js"></script>
 </body>
 </html>

--- a/Experience.html
+++ b/Experience.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Experience - James Dolan</title>
     <link rel="stylesheet" href="styles.css">
+    <script src="config.js" defer></script>
     <script src="scripts.js" defer></script>
 </head>
 <body>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# James Dolan Website
+
+This site uses EmailJS for the contact form. Credentials are not kept in the repository. Before running the site you need to provide the following values:
+
+- `EMAILJS_PUBLIC_KEY`
+- `EMAILJS_SERVICE_ID`
+- `EMAILJS_TEMPLATE_ID`
+
+## Providing credentials via a config file
+
+1. Copy `config.example.js` to `config.js`.
+2. Replace the placeholder values with your EmailJS credentials.
+3. Ensure `config.js` is **not** committed to version control. The `.gitignore` file already excludes it.
+
+## Providing credentials via environment variables
+
+Alternatively you can create `config.js` dynamically from environment variables when deploying. A simple script can be run during deployment:
+
+```bash
+echo "window.EMAILJS_PUBLIC_KEY='${EMAILJS_PUBLIC_KEY}';" > config.js
+echo "window.EMAILJS_SERVICE_ID='${EMAILJS_SERVICE_ID}';" >> config.js
+echo "window.EMAILJS_TEMPLATE_ID='${EMAILJS_TEMPLATE_ID}';" >> config.js
+```
+
+Make sure the environment variables are set in your deployment environment before running this script.

--- a/Skills.html
+++ b/Skills.html
@@ -155,6 +155,7 @@
         </div>
     </section>
 
+    <script src="config.js"></script>
     <script src="scripts.js"></script>
 </body>
 </html>

--- a/config.example.js
+++ b/config.example.js
@@ -1,0 +1,4 @@
+// Copy this file to config.js and set your EmailJS credentials.
+window.EMAILJS_PUBLIC_KEY = "YOUR_PUBLIC_KEY";
+window.EMAILJS_SERVICE_ID = "YOUR_SERVICE_ID";
+window.EMAILJS_TEMPLATE_ID = "YOUR_TEMPLATE_ID";

--- a/index.html
+++ b/index.html
@@ -94,6 +94,7 @@
     </footer>
 
     <script src="https://cdn.emailjs.com/dist/email.min.js"></script>
+    <script src="config.js"></script>
     <script src="scripts.js"></script>
 </body>
 </html>

--- a/scripts.js
+++ b/scripts.js
@@ -1,7 +1,7 @@
 // Contact Form Modal Handling
 document.addEventListener("DOMContentLoaded", () => {
     if (typeof emailjs !== "undefined") {
-        emailjs.init("d5p16jvVsbmTRVJyk"); // Initialize EmailJS
+        emailjs.init(window.EMAILJS_PUBLIC_KEY); // Initialize EmailJS
     } else {
         console.error("EmailJS failed to load.");
     }
@@ -160,7 +160,7 @@ document.getElementById("contact-form").addEventListener("submit", function(even
     console.log("Send button clicked! Form is submitting..."); // Debugging log
 
     if (typeof emailjs !== "undefined") {
-        emailjs.sendForm("service_se211gh", "template_1ptonjd", this, "d5p16jvVsbmTRVJyk")
+        emailjs.sendForm(window.EMAILJS_SERVICE_ID, window.EMAILJS_TEMPLATE_ID, this, window.EMAILJS_PUBLIC_KEY)
             .then(response => {
                 alert("Message sent successfully!");
                 document.getElementById("contact-form").reset();


### PR DESCRIPTION
## Summary
- make EmailJS IDs configurable via `config.js`
- document configuration via `config.example.js` and README
- load configuration in the HTML files
- ignore local `config.js` file in git

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687aa70e69d08333928b76d97f4c6d79