### PR TITLE
Remove personal contact info, add PwC logo, and update Napier education to DipHE (2025)

### DIFF
--- a/Education.html
+++ b/Education.html
@@ -31,8 +31,8 @@
             <!-- Degree 1 -->
             <div class="education-card">
                 <img src="Images/Napier.png" alt="Napier University Logo" class="education-logo">
-                <h3>Bachelor of Engineering (BEng), Cyber Security</h3>
-                <p class="school">Edinburgh Napier University | <span>September 2023 - September 2027</span></p>
+                <h3>Diploma of Higher Education (DipHE), Cyber Security</h3>
+                <p class="school">Edinburgh Napier University | <span>September 2023 - September 2025</span></p>
                 <a href="https://www.napier.ac.uk/study-with-us/apprenticeships/beng-hons-cybersecurity-ga#:~:text=As%20a%20Graduate%20Apprentice%20you,embedded%20in%20your%20working%20practices." target="_blank" rel="noopener noreferrer" class="edu-link">
                     Learn More
                 </a>

--- a/Experience.html
+++ b/Experience.html
@@ -24,7 +24,7 @@
         <h2>Professional Experience</h2>
         <div class="experience-grid">
             <div class="experience-card modal-trigger" data-modal="modal-pwc">
-                <img src="Images/profile.jpeg" alt="PwC profile icon" class="company-logo">
+                <img src="Images/pwc_logo.svg" alt="PwC logo" class="company-logo">
                 <h3>SOAR Engineer</h3>
                 <p><strong>PwC | July 2025 - Present</strong></p>
             </div>

--- a/Images/pwc_logo.svg
+++ b/Images/pwc_logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 200" role="img" aria-labelledby="title desc">
+  <title id="title">PwC logo</title>
+  <desc id="desc">Stylized PwC text with orange bars.</desc>
+  <rect width="360" height="200" fill="white"/>
+  <polygon points="190,40 255,40 240,65 175,65" fill="#ff5f00"/>
+  <polygon points="145,62 210,62 195,87 130,87" fill="#ff5f00"/>
+  <text x="95" y="140" font-size="92" font-family="Georgia, 'Times New Roman', serif" font-weight="700" fill="#000">pwc</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
 
     <section class="contact-banner">
       <h2>Let's Connect</h2>
-      <p>Email: dolan_777@hotmail.com | Phone: 07485176543 | LinkedIn: linkedin.com/in/james-dolan-3686A869</p>
+      <p>LinkedIn: linkedin.com/in/james-dolan-3686A869</p>
       <a href="#contact-modal" class="btn">Get In Touch</a>
     </section>
 


### PR DESCRIPTION
### Motivation
- Remove personally-identifying contact details from the public homepage for privacy reasons.
- Replace an unintended personal photo in the PwC experience card with a proper PwC logo asset.
- Correct the Edinburgh Napier entry to the appropriate qualification name and end date.

### Description
- Removed the email and phone line from the contact banner in `index.html`, leaving only the LinkedIn link.
- Replaced the experience image in `Experience.html` from `Images/profile.jpeg` to `Images/pwc_logo.svg` and added the new `Images/pwc_logo.svg` file.
- Updated the Napier education card in `Education.html` to `Diploma of Higher Education (DipHE), Cyber Security` and changed the end date to `September 2025`.
- Staged and committed the modified files (`index.html`, `Experience.html`, `Education.html`) and the new image asset to the repository.

### Testing
- Used `rg`/search and `git diff` to verify the intended changes are present in `index.html`, `Experience.html`, `Education.html`, and `Images/pwc_logo.svg`, which matched expected diffs (succeeded).
- Performed `git commit` to record the changes, which completed successfully.
- Attempted to run an automated visual check with Playwright via `node -e` to capture screenshots, which failed because the `playwright` module is not installed in this environment (failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04e06c3b488333abb46ec1bb04a29a)